### PR TITLE
This commit fixes two issues:

### DIFF
--- a/src/ghijira/core.clj
+++ b/src/ghijira/core.clj
@@ -147,11 +147,9 @@
 (defn format-comment [c]
   (let [created-at (tf/parse gh-formatter (:created_at c))
         comment-text (comment-or-event-to-text c)]
-    (str "Comment:"
-         (get-user c)
-         ":"
-         (tf/unparse jira-formatter created-at)
-         ":" \newline \newline
+    (str (tf/unparse jira-formatter created-at)
+         ";" (get-user c)
+         ";" \newline \newline
          comment-text)))
 
 (defn get-labels
@@ -183,7 +181,7 @@
         "Task" ; issue type
         milestone-dashes
         (if (= "closed" (:state issue)) "Closed" "Open")
-        (if (= "closed" (:state issue)) "Fixed" "Unresolved")
+        (if (= "closed" (:state issue)) "Fixed" "")
         (get-user issue)
         (get-assignee issue)
         (get-labels issue))


### PR DESCRIPTION
1) According to JIRA, to preserve the comment author/date use format. E.g. "05/05/2010 11:20:30; adam; This is a comment."  Otherwise, comments after importing did not preserve the commenter (the commenter name was part of the comment body)

2) JIRA has a reserved "Unresolved" state for Status; if you specify the string "Unresolved" it puts the JIRA issue into an undefined state, and the issue will not show up in users' filters.
