### PR TITLE
Change expected to match output in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ JIRA.csv
 /target
 config-*.clj
 .nrepl-port
-
+testdata/temp/*

--- a/test/ghijira/core_test.clj
+++ b/test/ghijira/core_test.clj
@@ -7,7 +7,7 @@
     (is (= [2] (find-missing-issues issues)))))
 
 (deftest should-identify-missing-issues-from-number-1
-  (let [issues [{:number 3 :title "Third"} ]]
+  (let [issues [{:number 3 :title "Third"}]]
     (is (= [1 2] (find-missing-issues issues)))))
 
 ;; End-to-end test
@@ -45,6 +45,7 @@
                 :user "anne"
                 :comment-contents []}
         issues [issue3 issue1 issue2]] ; random order
-    (binding [*maxcmt* 25]
+    (binding [*maxcmt* 25
+              *issue-offset* 0]
       (export-issues-to-file issues "testdata/temp/out.csv")
       (is (= (slurp "testdata/expected_jira.csv") (slurp"testdata/temp/out.csv"))))))

--- a/testdata/expected_jira.csv
+++ b/testdata/expected_jira.csv
@@ -1,8 +1,8 @@
-Issue Id,Summary,Description,Date Created,Date Modified,Issue type,Milestone,Status,Reporter,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments
-1,First,First issue,09/08/12 03:00:00 PM,09/08/12 03:15:00 PM,Task,,Open,,,,,,,,,,,,,,,,,,,,,,,,,,
-2,Second,Second issue,09/08/12 04:00:00 PM,09/08/12 04:15:00 PM,Task,,Closed,,"Comment::09/08/12 04:13:00 PM:
+Issue Id,Summary,Description,Date Created,Date Modified,Issue type,Milestone,Status,Resolution,Reporter,Assignee,Labels,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments,Comments
+1,First,First issue,09/08/12 03:00:00 PM,09/08/12 03:15:00 PM,Task,,Open,Unresolved,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+2,Second,Second issue,09/08/12 04:00:00 PM,09/08/12 04:15:00 PM,Task,,Closed,Fixed,,,,"Comment::09/08/12 04:13:00 PM:
 
 First comment by betty","Comment::09/08/12 04:15:00 PM:
 
 Second comment by anne",,,,,,,,,,,,,,,,,,,,,,,
-3,Third,Third issue,09/08/12 05:00:00 PM,09/08/12 05:15:00 PM,Task,,Open,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,Third,Third issue,09/08/12 05:00:00 PM,09/08/12 05:15:00 PM,Task,,Open,Unresolved,,,,,,,,,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Fixes tests not passing. 
- Changed expected output to match what is being output. 
- Added binding for *issue-offset* and folder (required for tests to be run).